### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The installation is easy. You can download a prebuilt binary from [releases page
 If you have go1.13+ compiler installed and configured:
 
 ```bash
-▶ GO111MODULE=on go get -v github.com/dwisiswant0/crlfuzz/cmd/crlfuzz
+▶ GO111MODULE=on go install github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@latest
 ```
 
 In order to update the tool, you can use `-u` flag with go get command.


### PR DESCRIPTION
### Summary

Installing executables with "go get" in module mode is deprecated.
"go install pkg@version" should be used instead.
For more information, see https://golang.org/doc/go-get-install-deprecation

### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- Makes the installation compatible with the latest version of Go
- Provides error-free installation

### How has this been tested?

Proof: https://golang.org/doc/go-get-install-deprecation